### PR TITLE
feat: add passphrase support for root private key

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -117,7 +117,7 @@ func signCertificate(cfg model.Certificate) (*x509.Certificate, error) {
 		}
 
 		// read parent key
-		cfg.ParentKey, err = util.ReadPrivateKey(cfg.ParentKeyPath)
+		cfg.ParentKey, err = util.ReadPrivateKey(cfg.ParentKeyPath, cfg.Passphrase)
 		if err != nil {
 			return nil, err
 		}

--- a/cert.go
+++ b/cert.go
@@ -71,13 +71,13 @@ func signCertificate(cfg model.Certificate) (*x509.Certificate, error) {
 		// root certificate self-signed
 		if !util.FileExists(cfg.KeyFilePath) {
 			logger.Warn("signCertificate", "private key does not exist")
-			cfg.ParentKey, err = CreatePrivateKey(cfg.KeyFilePath)
+			cfg.ParentKey, err = CreatePrivateKey(cfg.KeyFilePath, cfg.Passphrase)
 			if err != nil {
 				return nil, err
 			}
 		}
 		if cfg.ParentKey == nil {
-			cfg.ParentKey, err = util.ReadPrivateKey(cfg.KeyFilePath)
+			cfg.ParentKey, err = util.ReadPrivateKey(cfg.KeyFilePath, cfg.Passphrase)
 			if err != nil {
 				return nil, err
 			}
@@ -159,11 +159,12 @@ func signCertificate(cfg model.Certificate) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-func SignRootCertificate(yamlPath string) (*x509.Certificate, error) {
+func SignRootCertificate(yamlPath string, passphrase string) (*x509.Certificate, error) {
 	var cfg model.CAConfig
 	if err := util.ReadYamlFileToStruct(yamlPath, &cfg); err != nil {
 		return nil, err
 	}
+	cfg.CA.Root.Passphrase = passphrase
 	cert, err := signCertificate(cfg.CA.Root)
 	if err != nil {
 		return nil, err

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -16,6 +16,7 @@ var certCmd = &cobra.Command{
 func init() {
 	certCmd.Flags().StringP("yaml", "y", "", "specify the configuration yaml file path")
 	certCmd.Flags().StringP("type", "t", "", "specify the type of the certificate: [root, intermediate, server, client]")
+	certCmd.Flags().StringP("passphrase", "p", "", "passphrase for decrypting private key")
 
 	if err := certCmd.MarkFlagRequired("yaml"); err != nil {
 		logger.Error("cert-go", err.Error())
@@ -44,10 +45,16 @@ func createCert(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	passphrase, err := cmd.Flags().GetString("passphrase")
+	if err != nil {
+		logger.Error("cert-go", err.Error())
+		return
+	}
+
 	logger.Info("cert-go", "start to create cert")
 	switch certType {
 	case "root":
-		_, err = certgo.SignRootCertificate(yamlPath)
+		_, err = certgo.SignRootCertificate(yamlPath, passphrase)
 	case "intermediate":
 		_, err = certgo.SignIntermediateCertificate(yamlPath)
 	case "server":

--- a/cmd/privateKey.go
+++ b/cmd/privateKey.go
@@ -23,7 +23,7 @@ func init() {
 	createCmd.AddCommand(privateKeyCmd)
 }
 
-func createPrivateKey(cmd *cobra.Command, args []string) {
+func createPrivateKey(cmd *cobra.Command, args []string, passphrase string) {
 	outputPath, err := cmd.Flags().GetString("out")
 	if err != nil {
 		logger.Error("cert-go", err.Error())
@@ -31,7 +31,7 @@ func createPrivateKey(cmd *cobra.Command, args []string) {
 	}
 
 	logger.Info("cert-go", "start to create private key")
-	if _, err := certgo.CreatePrivateKey(outputPath); err != nil {
+	if _, err := certgo.CreatePrivateKey(outputPath, passphrase); err != nil {
 		logger.Error("cert-go", "failed to create private key")
 		return
 	}

--- a/csr.go
+++ b/csr.go
@@ -28,14 +28,14 @@ func CreateCsr(cfg model.Certificate) (*x509.CertificateRequest, error) {
 	// check private key exists
 	if !util.FileExists(cfg.KeyFilePath) {
 		logger.Warn("CreateCsr", "private key does not exist")
-		privateKey, err = CreatePrivateKey(cfg.KeyFilePath)
+		privateKey, err = CreatePrivateKey(cfg.KeyFilePath, cfg.Passphrase)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if privateKey == nil {
-		privateKey, err = util.ReadPrivateKey(cfg.KeyFilePath)
+		privateKey, err = util.ReadPrivateKey(cfg.KeyFilePath, cfg.Passphrase)
 		if err != nil {
 			return nil, err
 		}

--- a/model/model_certificate.go
+++ b/model/model_certificate.go
@@ -9,6 +9,7 @@ type Certificate struct {
 	Type         string `yaml:"type"`
 	CertFilePath string `yaml:"cert"`
 	KeyFilePath  string `yaml:"private_key"`
+	Passphrase   string `yaml:"passphrase"`
 	CsrFilePath  string `yaml:"csr"`
 
 	ParentCertPath string `yaml:"parent_cert"`

--- a/util/readPrivateKey.go
+++ b/util/readPrivateKey.go
@@ -10,7 +10,7 @@ import (
 	logger "github.com/Alonza0314/logger-go"
 )
 
-func ReadPrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
+func ReadPrivateKey(keyPath string, passphrase string) (*ecdsa.PrivateKey, error) {
 	keyPEM, err := os.ReadFile(keyPath)
 	if err != nil {
 		logger.Error("ReadPrivateKey", err.Error())
@@ -23,7 +23,17 @@ func ReadPrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
 		return nil, errors.New("failed to decode PEM block")
 	}
 
-	privateKey, err := x509.ParseECPrivateKey(block.Bytes)
+	var der []byte
+	if x509.IsEncryptedPEMBlock(block) {
+		der, err = x509.DecryptPEMBlock(block, []byte(passphrase))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		der = block.Bytes
+	}
+
+	privateKey, err := x509.ParseECPrivateKey(der)
 	if err != nil {
 		logger.Error("ReadPrivateKey", err.Error())
 		return nil, err


### PR DESCRIPTION
Implemented passphrase support for the root private key.

Added a passphrase flag to the CLI command for certificate creation.

Passed the passphrase value through model.Certificate to signCertificate().

Applied encryption only for the root private key; other cert types remain unaffected.

Modified util.ReadPrivateKey() and CreatePrivateKey() to accept passphrase input.

Ensured no passphrase is stored in YAML for security concerns.

Student ID: 112550198
