### PR TITLE
Add the file path to the error message in file operations

### DIFF
--- a/util/fileOperation.go
+++ b/util/fileOperation.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,7 +17,7 @@ func FileExists(filePath string) bool {
 func FileWrite(filePath string, data []byte, code fs.FileMode) error {
 	err := os.WriteFile(filePath, data, code)
 	if err != nil {
-		logger.Error("FileWrite", filePath+", "+err.Error())
+		logger.Error("FileWrite", fmt.Sprintf("%s, file path: %s", err.Error(), filePath))
 	}
 	return err
 }
@@ -24,7 +25,7 @@ func FileWrite(filePath string, data []byte, code fs.FileMode) error {
 func FileDelete(filePath string) error {
 	err := os.Remove(filePath)
 	if err != nil {
-		logger.Error("FileDelete", filePath+", "+err.Error())
+		logger.Error("FileDelete", fmt.Sprintf("%s, file path: %s", err.Error(), filePath))
 	}
 	return err
 }
@@ -36,7 +37,7 @@ func FileDir(filePath string) string {
 func FileDirCreate(filePath string) error {
 	err := os.MkdirAll(filepath.Dir(filePath), 0775)
 	if err != nil {
-		logger.Error("FileDirCreate", filePath+", "+err.Error())
+		logger.Error("FileDirCreate", fmt.Sprintf("%s, file path: %s", err.Error(), filePath))
 	}
 	return err
 }

--- a/util/fileOperation.go
+++ b/util/fileOperation.go
@@ -37,7 +37,7 @@ func FileDir(filePath string) string {
 func FileDirCreate(filePath string) error {
 	err := os.MkdirAll(filepath.Dir(filePath), 0775)
 	if err != nil {
-		logger.Error("FileDirCreate", fmt.Sprintf("%s, file path: %s", err.Error(), filePath))
+		logger.Error("FileDirCreate", fmt.Sprintf("%s, file directory path: %s", err.Error(), filepath.Dir(filePath)))
 	}
 	return err
 }

--- a/util/fileOperation.go
+++ b/util/fileOperation.go
@@ -16,7 +16,7 @@ func FileExists(filePath string) bool {
 func FileWrite(filePath string, data []byte, code fs.FileMode) error {
 	err := os.WriteFile(filePath, data, code)
 	if err != nil {
-		logger.Error("FileWrite", err.Error())
+		logger.Error("FileWrite", filePath+", "+err.Error())
 	}
 	return err
 }
@@ -24,7 +24,7 @@ func FileWrite(filePath string, data []byte, code fs.FileMode) error {
 func FileDelete(filePath string) error {
 	err := os.Remove(filePath)
 	if err != nil {
-		logger.Error("FileDelete", err.Error())
+		logger.Error("FileDelete", filePath+", "+err.Error())
 	}
 	return err
 }
@@ -36,7 +36,7 @@ func FileDir(filePath string) string {
 func FileDirCreate(filePath string) error {
 	err := os.MkdirAll(filepath.Dir(filePath), 0775)
 	if err != nil {
-		logger.Error("FileDirCreate", err.Error())
+		logger.Error("FileDirCreate", filePath+", "+err.Error())
 	}
 	return err
 }


### PR DESCRIPTION
When using cert-go to generate a key, I encountered the following error. It took me a long time to locate the source of the configuration issue, because the error message did not include the file path. This made it difficult to identify problems in the YAML configuration. Therefore, I would like to include the file path in the error message to make debugging easier.

sherry@DESKTOP-GL631SG:/mnt/d/Downloads$ ./cert-go-linux-amd64-v2-3-2 create cert -t root -y /mnt/d/cert-configs/root.yaml
2025/04/16 21:56:36 [INFO] [cert-go] start to create cert
2025/04/16 21:56:36 [INFO] [signCertificate] signing certificate
2025/04/16 21:56:36 [WARN] [signCertificate] CSR file does not exist
2025/04/16 21:56:36 [INFO] [CreateCsr] creating csr
2025/04/16 21:56:36 [WARN] [CreateCsr] private key does not exist
2025/04/16 21:56:36 [INFO] [CreatePrivateKey] creating private key
2025/04/16 21:56:36 [EROR] [FileWrite] open : no such file or directory
2025/04/16 21:56:36 [EROR] [cert-go] failed to create cert